### PR TITLE
drop python 3.8

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-latest]
-        pyv: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        pyv: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-latest]
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - { os: ubuntu-latest, python: "pypy3.9" }
           - { os: ubuntu-latest, python: "pypy3.10" }

--- a/fancycompleter/__init__.py
+++ b/fancycompleter/__init__.py
@@ -8,7 +8,7 @@ import rlcompleter
 import sys
 import types
 from itertools import count
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 try:
     from .version import __version__
@@ -118,7 +118,7 @@ class DefaultConfig:
             self.use_colors = supports_color
 
 
-def my_execfile(filename: str, mydict: Dict[str, Any]):
+def my_execfile(filename: str, mydict: dict[str, Any]):
     with open(filename) as f:
         code = compile(f.read(), filename, "exec")
         exec(code, mydict)
@@ -218,7 +218,7 @@ class Completer(rlcompleter.Completer, ConfigurableClass):
         # disable automatic insertion of '(' for global callables
         return word
 
-    def global_matches(self, text: str) -> List[str]:
+    def global_matches(self, text: str) -> list[str]:
         import keyword
 
         names = rlcompleter.Completer.global_matches(self, text)
@@ -227,7 +227,7 @@ class Completer(rlcompleter.Completer, ConfigurableClass):
             return [prefix]
 
         names.sort()
-        values: List[Optional[str]] = []
+        values: list[Optional[str]] = []
         for name in names:
             clean_name = name.rstrip(": ")
             if clean_name in keyword.kwlist:
@@ -241,7 +241,7 @@ class Completer(rlcompleter.Completer, ConfigurableClass):
             return self.color_matches(names, values)
         return names
 
-    def attr_matches(self, text: str) -> List[str]:
+    def attr_matches(self, text: str) -> list[str]:
         expr, attr = text.rsplit(".", 1)
         if "(" in expr or ")" in expr:  # don't call functions
             return []
@@ -298,7 +298,7 @@ class Completer(rlcompleter.Completer, ConfigurableClass):
             names.append(" ")
         return names
 
-    def color_matches(self, names: List[str], values):
+    def color_matches(self, names: list[str], values):
         matches = [
             self.color_for_obj(i, name, obj)
             for i, name, obj in zip(count(), names, values)
@@ -321,7 +321,7 @@ class Completer(rlcompleter.Completer, ConfigurableClass):
         return f"\x1b[{i:03d};00m" + Color.set(color, name)
 
 
-def commonprefix(names: List[str], base: str = ""):
+def commonprefix(names: list[str], base: str = ""):
     """return the common prefix of all 'names' starting with 'base'"""
     if base:
         names = [x for x in names if x.startswith(base)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.ruff]
 line-length = 88
-target-version = "py38"
+target-version = "py39"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
drop python 3.8 (last security update was in September 2024: https://www.python.org/downloads/release/python-3820/)
