### PR TITLE
drop pyrepl

### DIFF
--- a/fancycompleter/__init__.py
+++ b/fancycompleter/__init__.py
@@ -338,8 +338,12 @@ def commonprefix(names: list[str], base: str = ""):
     return s1
 
 
-def has_leopard_libedit(config):
-    # Detect if we are using Leopard's libedit.
+def has_libedit(config) -> bool:
+    # https://docs.python.org/3/library/readline.html#readline.backend
+    if sys.version_info >= (3, 13) and hasattr(config.readline, "backend"):
+        return config.readline.backend == "editline"
+
+    # Detect if we are using libedit/editline.
     # Adapted from IPython's rlineimpl.py.
     if config.using_pyrepl or sys.platform != "darwin":
         return False
@@ -353,7 +357,7 @@ def setup() -> Completer:
     """Install fancycompleter as the default completer for readline."""
     completer = Completer()
     readline = completer.config.readline
-    if has_leopard_libedit(completer.config):
+    if has_libedit(completer.config):
         readline.parse_and_bind("bind ^I rl_complete")
     else:
         readline.parse_and_bind("tab: complete")

--- a/fancycompleter/__init__.py
+++ b/fancycompleter/__init__.py
@@ -2,6 +2,8 @@
 fancycompleter: colorful TAB completion for Python prompt
 """
 
+from __future__ import annotations
+
 import contextlib
 import os.path
 import rlcompleter
@@ -9,7 +11,7 @@ import sys
 import types
 from code import InteractiveConsole
 from itertools import count
-from typing import Any, Optional
+from typing import Any
 
 try:
     from .version import __version__
@@ -125,8 +127,8 @@ def my_execfile(filename: str, mydict: dict[str, Any]):
 
 
 class ConfigurableClass:
-    DefaultConfig: Optional[type] = None
-    config_filename: Optional[str] = None
+    DefaultConfig: type | None = None
+    config_filename: str | None = None
 
     def get_config(self, Config):
         if Config is not None:
@@ -228,7 +230,7 @@ class Completer(rlcompleter.Completer, ConfigurableClass):
             return [prefix]
 
         names.sort()
-        values: list[Optional[str]] = []
+        values: list[str | None] = []
         for name in names:
             clean_name = name.rstrip(": ")
             if clean_name in keyword.kwlist:
@@ -387,7 +389,7 @@ def setup_history(completer, persist_history: str):
     atexit.register(save_history)
 
 
-def interact(persist_history: Optional[str] = None):
+def interact(persist_history: str | None = None):
     """
     Main entry point for fancycompleter: run an interactive Python session
     after installing fancycompleter.

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
         "Topic :: Utilities",
     ],
     install_requires=[
-        "pyrepl @ git+https://github.com/bretello/pyrepl@0.11.2",
         "pyreadline3;platform_system=='Windows'",
     ],
     extras_require={


### PR DESCRIPTION
- use builtin pyrepl instead of fork (finally getting rid of the [pyrepl fork](https://github.com/bretello/pyrepl) 🥳)
- use modern syntax for type hints
- improve libedit/editline detection
