### PR TITLE
PyPi release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,13 @@ jobs:
       - name: Build
         run: nox -s build
 
-      # disabled until we get permissions for PyPI
-      # - name: Upload package
-      #   if: github.event_name == 'release'
-      #   uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish to PyPI
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          TWINE_USERNAME: "__token__"
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          twine upload dist/*
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ the stdlib's [rlcompleter](http://docs.python.org/library/rlcompleter.html) modu
 Its best feature is that the completions are displayed in different
 colors, depending on their type:
 
-![image](/screenshot.png)
+![image](https://raw.githubusercontent.com/bretello/fancycompleter/refs/heads/master/screenshot.png)
 
 In the image above, strings are shown in green, functions in blue,
 integers and boolean in yellows, `None` in gray, types and classes in

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ fuchsia. Everything else is plain white.
 First, install the module with `pip`:
 
 ```bash
-pip install git+https://github.com/bretello/fancycompleter
+pip install fancycompleter
 ```
 
 Then, at the Python interactive prompt:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Tests](https://github.com/bretello/fancycompleter/actions/workflows/tests.yaml/badge.svg)](https://github.com/bretello/fancycompleter/actions/workflows/tests.yaml)
 [![codecov](https://codecov.io/gh/bretello/fancycompleter/graph/badge.svg?token=M70VF5GAP8)](https://codecov.io/gh/bretello/fancycompleter)
+[![PyPI version](https://img.shields.io/pypi/v/fancycompleter.svg)](https://pypi.org/project/fancycompleter/)
 
 ## What is is?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ requires-python = ">=3.8"
 dynamic = ["version"]
 dependencies = [
   "pyreadline3;platform_system=='Windows'",
-  "pyrepl @ git+https://github.com/bretello/pyrepl@0.11.2 ; python_version < '3.13'"
+  "pyrepl>=0.11.3; python_version < '3.13'"
 ]
 
 [project.urls]


### PR DESCRIPTION
- gha: release: enable PyPi publishing
- deps: use `pyrepl>=0.11.3` from PyPi
- README: 
    * update screenshot
    * update installation instructions
    * add PyPi version badge
