### PR TITLE
windows: remove pyreadline dependency for python >= 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ keywords = ["rlcompleter", "prompt", "color", "completion"]
 requires-python = ">=3.8"
 dynamic = ["version"]
 dependencies = [
-  "pyreadline3;platform_system=='Windows'",
+  "pyreadline3; platform_system=='Windows' and python_version < '3.13'",
   "pyrepl>=0.11.3; python_version < '3.13'"
 ]
 


### PR DESCRIPTION
Related: https://github.com/bretello/pdbpp/issues/47 and #41 