### PR TITLE
Fix import pyreadline for python >=3.13

### DIFF
--- a/fancycompleter/__init__.py
+++ b/fancycompleter/__init__.py
@@ -77,6 +77,7 @@ class DefaultConfig:
         if sys.version_info >= (3, 13):
             import _pyrepl.completing_reader
             import _pyrepl.readline
+            sys.modules["readline"] = _pyrepl.readline
 
             self.using_pyrepl = True
             return _pyrepl.readline, True


### PR DESCRIPTION
In many parts of the code, including in the system library `cmd`, the missing `readline` library is imported.
To prevent an import error when `import readline` is executed in such places, we assign:
`sys.modules["readline"] = _pyrepl.readline`
This prevents an import error when `import readline` is executed in such places.