### PR TITLE
find_pyrepl: only set sys.modules['readline'] on win32

### DIFF
--- a/fancycompleter/__init__.py
+++ b/fancycompleter/__init__.py
@@ -78,7 +78,9 @@ class DefaultConfig:
             import _pyrepl.completing_reader
             import _pyrepl.readline
 
-            sys.modules["readline"] = _pyrepl.readline
+            # readline is not available on windows by default
+            if sys.platform == "win32":
+                sys.modules["readline"] = _pyrepl.readline
 
             self.using_pyrepl = True
             return _pyrepl.readline, True


### PR DESCRIPTION
Avoid overriding `sys.modules['readline']` when we can
